### PR TITLE
Allow variables in url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,12 @@ executors:
   default:
     working_directory: /go/src/github.com/alexbrazier/go-url
     docker:
-      - image: circleci/golang:1.11-node
+      - image: circleci/golang:1.12-node
 
   browsers:
     working_directory: /go/src/github.com/alexbrazier/go-url
     docker:
-      - image: circleci/golang:1.11-node-browsers
+      - image: circleci/golang:1.12-node-browsers
       - image: circleci/postgres:9.6.2-alpine
         environment:
           POSTGRES_USER: postgres

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple URL shortener written in Go with a React frontend and Postgres database
 - Alias a key to point to another short url
 - Open multiple pages at once by separating keys with a comma
 - Alias a key to point to multiple other keys
+- Use variables in URLs
 - Opensearch integration to provide suggestions directly to browser
 - Frontend to view most popular searches and search to find existing links
 - Frontend to allow anyone to add and edit links

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -46,7 +46,7 @@ func Init(e *echo.Echo) {
 
 	// Setup routes
 	e.GET("/opensearch.xml", h.Opensearch)
-	e.GET("/:key", h.Url)
+	e.GET("/*", h.Url)
 	e.POST("/:key", h.CreateUrl)
 	e.PUT("/:key", h.UpdateUrl)
 

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -46,6 +46,7 @@ func Init(e *echo.Echo) {
 
 	// Setup routes
 	e.GET("/opensearch.xml", h.Opensearch)
+	e.GET("/:key", h.Url)
 	e.GET("/*", h.Url)
 	e.POST("/:key", h.CreateUrl)
 	e.PUT("/:key", h.UpdateUrl)

--- a/api/handler/url.go
+++ b/api/handler/url.go
@@ -32,7 +32,8 @@ func (h *Handler) getSetDifference(keys []string, found []*model.URL) []string {
 // Url is the handler function for finding a url
 // It will redirect the user to the desired url if one exists
 func (h *Handler) Url(c echo.Context) (err error) {
-	key := strings.ToLower(c.Param("key"))
+	key := c.Request().URL.Path[1:]
+	fmt.Println(key)
 	keys := strings.Split(key, ",")
 
 	u, err := urlModel.GetUrlsFromKeys(keys)

--- a/api/handler/url.go
+++ b/api/handler/url.go
@@ -22,7 +22,10 @@ func remove(s []string, r string) []string {
 }
 
 func (h *Handler) getSetDifference(keys []string, found []*model.URL) []string {
-	newKeys := keys
+	var newKeys []string
+	for _, key := range keys {
+		newKeys = append(newKeys, strings.Split(key, "/")[0])
+	}
 	for _, item := range found {
 		newKeys = remove(newKeys, item.Key)
 	}

--- a/api/handler/url.go
+++ b/api/handler/url.go
@@ -33,7 +33,6 @@ func (h *Handler) getSetDifference(keys []string, found []*model.URL) []string {
 // It will redirect the user to the desired url if one exists
 func (h *Handler) Url(c echo.Context) (err error) {
 	key := c.Request().URL.Path[1:]
-	fmt.Println(key)
 	keys := strings.Split(key, ",")
 
 	u, err := urlModel.GetUrlsFromKeys(keys)

--- a/api/model/url.go
+++ b/api/model/url.go
@@ -65,8 +65,6 @@ func (u *URL) GetUrlsFromKeys(keys []string) ([]*URL, error) {
 		params[actualKey] = remaining
 		actualKeys = append(actualKeys, actualKey)
 	}
-	fmt.Println(actualKeys)
-	fmt.Println(params)
 	err := db.GetDB().Model(&urls).WhereIn("key in (?)", pg.In(actualKeys)).Select()
 	if err != nil {
 		return nil, err
@@ -77,11 +75,7 @@ func (u *URL) GetUrlsFromKeys(keys []string) ([]*URL, error) {
 		}
 		if url.URL != "" {
 			for i, param := range params[url.Key] {
-				fmt.Println(url.URL)
-
 				url.URL = strings.ReplaceAll(url.URL, fmt.Sprintf("{{$%d}}", i+1), param)
-				fmt.Println(url.URL)
-				fmt.Println(fmt.Sprintf("{{$%d}}", i+1))
 			}
 		} else {
 			for i, alias := range url.Alias {

--- a/api/model/url.go
+++ b/api/model/url.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/alexbrazier/go-url/api/db"
 	"github.com/go-pg/pg"
@@ -56,8 +57,39 @@ func (u *URL) IncrementViewCount(keys []string) error {
 // GetUrlsFromKeys returns all the db records that match the keys
 func (u *URL) GetUrlsFromKeys(keys []string) ([]*URL, error) {
 	urls := []*URL{}
-	err := db.GetDB().Model(&urls).WhereIn("key in (?)", pg.In(keys)).Select()
-	return urls, err
+	params := make(map[string][]string)
+	actualKeys := make([]string, len(keys))
+	for _, key := range keys {
+		split := strings.Split(key, "/")
+		actualKey, remaining := strings.ToLower(split[0]), split[1:]
+		params[actualKey] = remaining
+		actualKeys = append(actualKeys, actualKey)
+	}
+	fmt.Println(actualKeys)
+	fmt.Println(params)
+	err := db.GetDB().Model(&urls).WhereIn("key in (?)", pg.In(actualKeys)).Select()
+	if err != nil {
+		return nil, err
+	}
+	for _, url := range urls {
+		if len(params[url.Key]) == 0 {
+			continue
+		}
+		if url.URL != "" {
+			for i, param := range params[url.Key] {
+				fmt.Println(url.URL)
+
+				url.URL = strings.ReplaceAll(url.URL, fmt.Sprintf("{{$%d}}", i+1), param)
+				fmt.Println(url.URL)
+				fmt.Println(fmt.Sprintf("{{$%d}}", i+1))
+			}
+		} else {
+			for i, alias := range url.Alias {
+				url.Alias[i] = fmt.Sprintf("%s/%s", alias, strings.Join(params[url.Key], "/"))
+			}
+		}
+	}
+	return urls, nil
 }
 
 // Search returns all the db records that match the keys

--- a/frontend/cypress/index.d.ts
+++ b/frontend/cypress/index.d.ts
@@ -2,7 +2,7 @@
 
 interface IKeyUrl {
   key?: string;
-  url: string;
+  url?: string;
 }
 declare namespace Cypress {
   interface Chainable<Subject> {

--- a/frontend/cypress/integration/add.spec.ts
+++ b/frontend/cypress/integration/add.spec.ts
@@ -29,6 +29,22 @@ context('Add', () => {
     cy.submitModal('Successfully set');
   });
 
+  it('should not allow key with invalid characters', () => {
+    cy.openAddModal();
+
+    cy.enterUrlDetails({ key: 'test$hello' });
+
+    cy.submitModal('The key provided is not valid');
+  });
+
+  it('should allow url with params included', () => {
+    cy.openAddModal();
+
+    cy.enterUrlDetails({ url: `${faker.internet.url()}/{{$1}}/test` });
+
+    cy.submitModal('Successfully set');
+  });
+
   it('should allow valid alias', () => {
     cy.openAddModal();
 

--- a/frontend/cypress/integration/core.spec.ts
+++ b/frontend/cypress/integration/core.spec.ts
@@ -50,4 +50,44 @@ context('Core', () => {
       .eq(2)
       .should('have.text', '1');
   });
+
+  it('should redirect to correct url when match found', done => {
+    const key = faker.random.uuid();
+    const url = 'https://github.com/test';
+    cy.addUrl({ key, url });
+
+    cy.request(`/${key}`).then((res: any) => {
+      expect(res.redirects).length.greaterThan(0);
+      expect(res.redirects[0]).to.equal(`307: ${url}`);
+      done();
+    });
+  });
+
+  it('should redirect to correct url when match found with variables', done => {
+    const key = faker.random.uuid();
+    const url = 'https://github.com/{{$1}}/{{$2}}';
+    cy.addUrl({ key, url });
+
+    cy.request(`/${key}/alexbrazier/go-url`).then((res: any) => {
+      expect(res.redirects).length.greaterThan(0);
+      expect(res.redirects[0]).to.equal(
+        `307: https://github.com/alexbrazier/go-url`,
+      );
+      done();
+    });
+  });
+
+  it('should redirect to correct url when match found with variables in different order', done => {
+    const key = faker.random.uuid();
+    const url = 'https://github.com/{{$2}}/{{$1}}';
+    cy.addUrl({ key, url });
+
+    cy.request(`/${key}/go-url/alexbrazier`).then((res: any) => {
+      expect(res.redirects).length.greaterThan(0);
+      expect(res.redirects[0]).to.equal(
+        `307: https://github.com/alexbrazier/go-url`,
+      );
+      done();
+    });
+  });
 });

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -19,7 +19,7 @@ Cypress.Commands.add(
 
     cy.get('input#url')
       .clear()
-      .type(url);
+      .type(url, { parseSpecialCharSequences: false });
   },
 );
 Cypress.Commands.add('submitModal', expectedAlert => {

--- a/frontend/src/components/Results/Results.tsx
+++ b/frontend/src/components/Results/Results.tsx
@@ -32,9 +32,11 @@ const Results: React.FC<ResultsProps> = ({ data, title }) => {
   const getFormattedUrl = (url: string) => {
     const regex = /({{\$\d+}})/g;
     const parts = url.split(regex);
-    return parts.map(part =>
+    return parts.map((part, i) =>
       part.match(regex) ? (
-        <span className={classes.urlReplace}>{part}</span>
+        <span key={i} className={classes.urlReplace}>
+          {part}
+        </span>
       ) : (
         part
       ),

--- a/frontend/src/components/Results/Results.tsx
+++ b/frontend/src/components/Results/Results.tsx
@@ -28,6 +28,18 @@ const Results: React.FC<ResultsProps> = ({ data, title }) => {
   const [selected, setSelected] = useState<IResult | null>(null);
   const clearSelected = useCallback(() => setSelected(null), []);
   const classes = useStyles({});
+
+  const getFormattedUrl = (url: string) => {
+    const regex = /({{\$\d+}})/g;
+    const parts = url.split(regex);
+    return parts.map(part =>
+      part.match(regex) ? (
+        <span className={classes.urlReplace}>{part}</span>
+      ) : (
+        part
+      ),
+    );
+  };
   return (
     <div>
       {selected && (
@@ -71,7 +83,7 @@ const Results: React.FC<ResultsProps> = ({ data, title }) => {
                       ))
                     ) : (
                       <a className={classes.url} href={`/${r.key}`}>
-                        {r.url}
+                        {getFormattedUrl(r.url)}
                         <LaunchIcon className={classes.launchIcon} />
                       </a>
                     )}

--- a/frontend/src/components/Results/useStyles.ts
+++ b/frontend/src/components/Results/useStyles.ts
@@ -33,6 +33,10 @@ const useStyles = makeStyles((theme: Theme) => ({
       maxWidth: 100,
     },
   },
+  urlReplace: {
+    color: '#4c4c4c',
+    fontWeight: 700,
+  },
 }));
 
 export default useStyles;


### PR DESCRIPTION
Closes #56 

Variables in the format `{{$1}}`, starting at `1` and incrementing, will be replaced with parameters in the key, split by `/`.

e.g. `test/param1` with the url `http://test.com/{{$1}}` will take you to `http://test.com/param1`

![image](https://user-images.githubusercontent.com/5689874/62903567-08462880-bd5b-11e9-829c-35da123c7f7b.png)
