### PR TITLE
Add x-forwarded-for trust level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,28 +79,29 @@ POSTGRES_PASS=password HOSTS=localhost APP_URI=http://localhost:3000 go run serv
 
 ## Enviroment Configuration
 
-| Env Var                | Required | Default        | Example                      | Description                                                                                            |
-| ---------------------- | -------- | -------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `HOSTS`                | yes      |                | go.domain.com,go2.domain.com | List of comma separated hosts that the server will be able to be accessed from                         |
-| `BLOCKED_HOSTS`        |          |                | go.domain.com,go2.domain.com | List of hosts you want to block from being linked - HOSTS are already included to stop recursive calls |
-| `APP_URI`              | yes      |                | https://go.domain.com        | Default URI of app - used to link back to app                                                          |
-| `PORT`                 |          | 1323           |                              | Port the app will run on                                                                               |
-| `DEBUG`                |          | false          |                              | Enable more logging                                                                                    |
-| `JSON_LOGS`            |          | false          |                              | Use JSON logs where possible                                                                           |
-| `POSTGRES_ADDR`        |          | localhost:5432 |                              | Postgres db address                                                                                    |
-| `POSTGRES_DATABASE`    |          | go             |                              | Postgres db name                                                                                       |
-| `POSTGRES_USER`        |          | postgres       |                              | Postgres user                                                                                          |
-| `POSTGRES_PASS`        |          | password       |                              | Postgres password                                                                                      |
-| `SLACK_TOKEN`          |          |                | xoxb-xxxxxxxxx-xxxxxxxx-xxxx | Slack OAuth token to enable slackbot                                                                   |
-| `SLACK_SIGNING_SECRET` |          |                | xxxxxxxxxxx                  | Slack signing secret to enable Slack `/go` command                                                     |
-| `SLACK_TEAM_ID`        |          |                | Txxxxxxxx                    | Slack team id to restrict slash command responses to single team                                       |
-| `ENABLE_AUTH`          |          | false          |                              | Enable Azure auth or not - if enabled, all other fields must be filled in                              |
-| `AD_TENANT_ID`         |          |                |                              | Azure AD tenant ID                                                                                     |
-| `AD_CLIENT_ID`         |          |                |                              | Azure AD client ID                                                                                     |
-| `AD_CLIENT_SECRET`     |          |                |                              | Azure AD client secret                                                                                 |
-| `SESSION_TOKEN`        |          |                |                              | Secret session token to store the user sessions                                                        |
-| `ALLOWED_IPS`          |          |                | 110.1.10.2,1.1.22.1          | IP addresses that are always allowed access, even with auth enabled                                    |
-| `ALLOW_FORWARDED_FOR`  |          | false          |                              | Retrieve origin IP from X-Forwarded-For header. Only enable if source is trusted, e.g. via Cloudfront  |
+| Env Var                     | Required | Default        | Example                      | Description                                                                                            |
+| --------------------------- | -------- | -------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `HOSTS`                     | yes      |                | go.domain.com,go2.domain.com | List of comma separated hosts that the server will be able to be accessed from                         |
+| `BLOCKED_HOSTS`             |          |                | go.domain.com,go2.domain.com | List of hosts you want to block from being linked - HOSTS are already included to stop recursive calls |
+| `APP_URI`                   | yes      |                | https://go.domain.com        | Default URI of app - used to link back to app                                                          |
+| `PORT`                      |          | 1323           |                              | Port the app will run on                                                                               |
+| `DEBUG`                     |          | false          |                              | Enable more logging                                                                                    |
+| `JSON_LOGS`                 |          | false          |                              | Use JSON logs where possible                                                                           |
+| `POSTGRES_ADDR`             |          | localhost:5432 |                              | Postgres db address                                                                                    |
+| `POSTGRES_DATABASE`         |          | go             |                              | Postgres db name                                                                                       |
+| `POSTGRES_USER`             |          | postgres       |                              | Postgres user                                                                                          |
+| `POSTGRES_PASS`             |          | password       |                              | Postgres password                                                                                      |
+| `SLACK_TOKEN`               |          |                | xoxb-xxxxxxxxx-xxxxxxxx-xxxx | Slack OAuth token to enable slackbot                                                                   |
+| `SLACK_SIGNING_SECRET`      |          |                | xxxxxxxxxxx                  | Slack signing secret to enable Slack `/go` command                                                     |
+| `SLACK_TEAM_ID`             |          |                | Txxxxxxxx                    | Slack team id to restrict slash command responses to single team                                       |
+| `ENABLE_AUTH`               |          | false          |                              | Enable Azure auth or not - if enabled, all other fields must be filled in                              |
+| `AD_TENANT_ID`              |          |                |                              | Azure AD tenant ID                                                                                     |
+| `AD_CLIENT_ID`              |          |                |                              | Azure AD client ID                                                                                     |
+| `AD_CLIENT_SECRET`          |          |                |                              | Azure AD client secret                                                                                 |
+| `SESSION_TOKEN`             |          |                |                              | Secret session token to store the user sessions                                                        |
+| `ALLOWED_IPS`               |          |                | 110.1.10.2,1.1.22.1          | IP addresses that are always allowed access, even with auth enabled                                    |
+| `ALLOW_FORWARDED_FOR`       |          | false          |                              | Retrieve origin IP from X-Forwarded-For header. Only enable if source is trusted, e.g. via Cloudfront  |
+| `FORWARDED_FOR_TRUST_LEVEL` |          | 1              |                              | Number of levels to trust X-Forwarded-For header - should map to number of proxies used                |
 
 ## FAQ
 


### PR DESCRIPTION
Lets you specify number of levels to look up x-forwarded-for header to get actual ip. Useful if using multiple proxies such as cloudfront and nginx.