### PR TITLE
only compile regexp once

### DIFF
--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -9,16 +9,18 @@ import (
 // Handler ...
 type Handler struct{}
 
-var urlModel = &model.URL{}
+var (
+	urlModel              = &model.URL{}
+	validateKeyRegexp     = regexp.MustCompile("^[\\w-]+$")
+	validateKeyPathRegexp = regexp.MustCompile("^[\\w-\\/]+$")
+)
 
 // ValidateKey validates a key against the required format
 func ValidateKey(key string) bool {
-	r, _ := regexp.Compile("^[\\w-]+$")
-	return r.MatchString(key)
+	return validateKeyRegexp.MatchString(key)
 }
 
 // ValidateKeyPath validates a key with optional parameters
 func ValidateKeyPath(key string) bool {
-	r, _ := regexp.Compile("^[\\w-\\/]+$")
-	return r.MatchString(key)
+	return validateKeyPathRegexp.MatchString(key)
 }

--- a/api/slackbot/slackbot.go
+++ b/api/slackbot/slackbot.go
@@ -12,7 +12,10 @@ import (
 	cache "github.com/patrickmn/go-cache"
 )
 
-var urlModel = &model.URL{}
+var (
+	urlModel             = &model.URL{}
+	getKeyFromTextRegexp = regexp.MustCompile("\\bgo ([\\w-\\/]+)\\b")
+)
 
 // SlackBot .
 type SlackBot struct {
@@ -22,9 +25,7 @@ type SlackBot struct {
 }
 
 func (s *SlackBot) getKeyFromText(text string) string {
-	r, _ := regexp.Compile("\\bgo ([\\w-\\/]+)\\b")
-
-	matches := r.FindStringSubmatch(text)
+	matches := getKeyFromTextRegexp.FindStringSubmatch(text)
 
 	if len(matches) != 2 {
 		return ""


### PR DESCRIPTION
refactored to regexp.MustCompile instead of ignoring the error and compiling the regexp on each function call